### PR TITLE
Add spi config for nice!nano v2 to turn RGB on

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -7,6 +7,7 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/rgb.h>
 
 
 
@@ -50,8 +51,43 @@
    &kp ESC   &kp EXCL &kp AT &kp HASH &kp DLLR &kp PRCNT   &kp CARET  &kp AMPS  &kp LPAR        &kp RPAR &kp FSLH &kp BSPC
    &kp LSHFT &trans   &trans &trans   &kp PIPE &kp TILDE   &kp BSLH   &kp EQUAL &kp LBKT        &kp RBKT &kp SEMI &kp GRAVE
    &kp LCTRL &trans   &trans &trans   &trans   &trans      &kp UNDER  &kp LBRC  &kp RBRC        &kp LT   &kp GT   &trans
-                    	     &kp LGUI &trans   &kp SPACE   &kp RET    &trans    &kp TAB
+                    	     &kp LGUI &trans   &rgb_ug RGB_TOG &rgb_ug RGB_EFF    &trans    &kp TAB
                         >;
                 };
         };
+};
+
+/*
+ * Temporarily here because nice nano v2 spi is not defined on ZMk Yet
+ * Source: https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/reviung41/boards/nice_nano.overlay
+ * GitHub Issue: https://github.com/zmkfirmware/zmk/issues/885
+ */
+
+&spi1 {
+   compatible = "nordic,nrf-spim";
+   status = "okay";
+   mosi-pin = <6>;
+   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+   sck-pin = <5>;
+   miso-pin = <7>;
+
+   led_strip: ws2812@0 {
+      compatible = "worldsemi,ws2812-spi";
+      label = "WS2812";
+
+      /* SPI */
+      reg = <0>; /* ignored, but necessary for SPI bindings */
+      spi-max-frequency = <4000000>;
+
+      /* WS2812 */
+      chain-length = <11>; /* arbitrary; change at will */
+      spi-one-frame = <0x70>;
+      spi-zero-frame = <0x40>;
+   };
+};
+
+/ {
+   chosen {
+      zmk,underglow = &led_strip;
+   };
 };


### PR DESCRIPTION
I copied from this https://github.com/Ardakilic/zmk-config/blob/master/config/reviung41.keymap#L12

Remember to uncomment this 2 line in corne.conf file
CONFIG_ZMK_RGB_UNDERGLOW=y
CONFIG_WS2812_STRIP=y in corne.conf file

To toggle RGB on/off, hold Raise and press Space
To switch RGB feature's effect, hold Raise and press Enter
You can change it whatever you want later :D

Hope this work!

